### PR TITLE
fix: support for enter key on web

### DIFF
--- a/lib/focusable_control_builder.dart
+++ b/lib/focusable_control_builder.dart
@@ -125,13 +125,14 @@ class FocusableControlState extends State<FocusableControlBuilder> {
     setState(() => _isPressed = isDown);
   }
 
-  /// By default, will bind the [ActivateIntent] from the flutter SDK to the onPressed callback.
-  /// This will enable SPACE and ENTER keys on most platforms.
+  /// By default, will bind [ActivateIntent] and [ButtonActivateIntent] from the flutter SDK
+  /// to the onPressed callback. This enables SPACE and ENTER keys on all platforms including web.
   /// Also accepts additional actions provided externally.
   Map<Type, Action<Intent>> _getKeyboardActions() {
     return {
       if (hasPressHandler) ...{
         ActivateIntent: CallbackAction<Intent>(onInvoke: (_) => _handlePressed()),
+        ButtonActivateIntent: CallbackAction<Intent>(onInvoke: (_) => _handlePressed()),
       },
       ...(widget.actions ?? {}),
     };


### PR DESCRIPTION
Problem: On Chrome (web), pressing Enter on focused buttons did nothing — only Spacebar worked for activation during tab navigation.

Root cause: Flutter maps Enter to `ButtonActivateIntent` on web, but to `ActivateIntent` on native platforms.